### PR TITLE
fix s390x failure

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -3,15 +3,13 @@ FROM debian:buster-20220801
 ARG DAPPER_HOST_ARCH
 ENV ARCH=${DAPPER_HOST_ARCH}
 
-RUN apt-get update && \
-    apt-get install -y apt-transport-https ca-certificates gnupg wget curl
+RUN apt-get install -y apt-transport-https ca-certificates gnupg wget curl
 
 RUN wget -O - https://download.docker.com/linux/debian/gpg | apt-key add - && \
     echo "deb [arch=${ARCH}] https://download.docker.com/linux/debian buster stable" >> /etc/apt/sources.list && \
     cat /etc/apt/sources.list
 
-RUN apt-get update && \
-    apt-get install -y bash git jq
+RUN apt-get install -y bash git jq
 
 RUN if [ "${ARCH}" = "s390x" ]; then \
         curl -L https://download.docker.com/linux/static/stable/s390x/docker-18.06.3-ce.tgz | tar xzvf - && \

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:buster-20220801
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH=${DAPPER_HOST_ARCH}

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,27 +1,9 @@
-FROM debian:buster-20220801
+FROM registry.suse.com/bci/bci-base:latest
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH=${DAPPER_HOST_ARCH}
 
-RUN apt-get install -y apt-transport-https ca-certificates gnupg wget curl
-
-RUN wget -O - https://download.docker.com/linux/debian/gpg | apt-key add - && \
-    echo "deb [arch=${ARCH}] https://download.docker.com/linux/debian buster stable" >> /etc/apt/sources.list && \
-    cat /etc/apt/sources.list
-
-RUN apt-get install -y bash git jq
-
-RUN if [ "${ARCH}" = "s390x" ]; then \
-        curl -L https://download.docker.com/linux/static/stable/s390x/docker-18.06.3-ce.tgz | tar xzvf - && \
-        cp docker/docker /usr/bin/ && \
-        chmod +x /usr/bin/docker; \
-    elif [ "${ARCH}" = "arm" ]; then \
-        curl -L https://download.docker.com/linux/static/stable/armhf/docker-18.06.3-ce.tgz | tar xzvf - && \
-        cp docker/docker /usr/bin/ && \
-        chmod +x /usr/bin/docker; \
-    else \
-        apt-get install -y docker-ce; \
-    fi
+RUN zypper refresh && zypper install -y wget bash git jq docker
 
 ENV DAPPER_ENV REPO OS ARCH TAG DRONE_TAG LOCAL_ARTIFACTS DOCKER_USERNAME DOCKER_PASSWORD
 ENV DAPPER_SOURCE /go/src/github.com/rancher/system-agent-installer-k3s/

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,9 +1,9 @@
-FROM registry.suse.com/bci/bci-base:latest
+FROM alpine:3.16
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH=${DAPPER_HOST_ARCH}
 
-RUN zypper refresh && zypper install -y wget bash git jq docker
+RUN apk update && apk add ca-certificates curl bash git jq docker
 
 ENV DAPPER_ENV REPO OS ARCH TAG DRONE_TAG LOCAL_ARTIFACTS DOCKER_USERNAME DOCKER_PASSWORD
 ENV DAPPER_SOURCE /go/src/github.com/rancher/system-agent-installer-k3s/


### PR DESCRIPTION
Debian is missing packages and container images for s390x. This PR replaces the Dapper base image wit SLE BCI.