### PR TITLE
Do not exit if an ETCD learner error is encountered

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ platform:
 
 steps:
 - name: build-linux-amd64
-  image: rancher/dapper:v0.5.6
+  image: rancher/dapper:v0.6.0
   environment:
     ARCH: amd64
   commands:
@@ -19,7 +19,7 @@ steps:
       path: /var/run/docker.sock
 
 - name: publish-linux-amd64
-  image: rancher/dapper:v0.5.6
+  image: rancher/dapper:v0.6.0
   environment:
     ARCH: amd64
     DOCKER_PASSWORD:
@@ -55,7 +55,7 @@ platform:
 
 steps:
 - name: build-linux-arm64
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.6.0
   environment:
     ARCH: arm64
   commands:
@@ -65,7 +65,7 @@ steps:
       path: /var/run/docker.sock
 
 - name: publish-linux-arm64
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.6.0
   environment:
     ARCH: arm64
     DOCKER_PASSWORD:
@@ -105,7 +105,7 @@ platform:
 
 steps:
 - name: build-linux-s390x
-  image: rancher/dapper:v0.5.8
+  image: rancher/dapper:v0.6.0
   environment:
     ARCH: s390x
   commands:
@@ -115,7 +115,7 @@ steps:
       path: /var/run/docker.sock
 
 - name: publish-linux-s390x
-  image: rancher/dapper:v0.5.8
+  image: rancher/dapper:v0.6.0
   environment:
     ARCH: s390x
     DOCKER_PASSWORD:

--- a/package/run.sh
+++ b/package/run.sh
@@ -20,7 +20,34 @@ else
     FORCE_RESTART=false
 fi
 
-env "INSTALL_K3S_FORCE_RESTART=${FORCE_RESTART}" "INSTALL_K3S_SKIP_DOWNLOAD=true" "INSTALL_K3S_SKIP_SELINUX_RPM=true" "INSTALL_K3S_SELINUX_WARN=true" installer.sh $@
+
+# work around for https://github.com/k3s-io/k3s/issues/2306
+# depends on journald being available on first boot, so this may not work on all providers (e.g. Digital Ocean)
+DELAY=10
+while ! env "INSTALL_K3S_FORCE_RESTART=${FORCE_RESTART}" "INSTALL_K3S_SKIP_DOWNLOAD=true" "INSTALL_K3S_SKIP_SELINUX_RPM=true" "INSTALL_K3S_SELINUX_WARN=true" installer.sh $@
+do
+    if ! systemctl cat k3s.service > /dev/null && echo $?; then
+        # if k3s.service can not be found then we are not a server node and thus will never encounter the 'too many learners' error, so we should just exit
+        echo "not a K3s server, not attempting error remediation"
+        exit 1
+    fi
+    # We need to get the right systemd service based off of the role we have, $INSTALL_K3S_EXEC will be set if we are a worker only node, in which case the systemd service is k3s-agent.service
+    journalctl -u k3s.service > k3s-service.txt
+    # Only use the logs for the latest restart of k3s, otherwise errors encountered after an ETCD join error will not be reported properly.
+    LAST_START_LINE=$(cat k3s-service.txt | grep "Starting k3s v1." -n  | cut -d: -f1 | tail -1)
+    if [[ "$LAST_START_LINE" -gt 0 ]]; then
+        LAST_LOGS=$(cat k3s-service.txt | sed -n "$((LAST_START_LINE))"',$p')
+        else
+        LAST_LOGS=$(cat k3s-service.txt)
+    fi
+    if ! echo "${LAST_LOGS}" | grep "ETCD join failed: etcdserver: too many learner members in cluster" -q && echo $?; then
+        exit 1
+        else
+        # We couldn't register as a learner, keep trying until we can
+        sleep "${DELAY}"
+    fi
+done
+
 
 if [ -n "${RESTART_STAMP}" ]; then
     echo "${RESTART_STAMP}" > "${RESTART_STAMP_FILE}"


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/39109

Problem: 
When multiple K3s ETCD nodes are registered at the same time (3 or more), a race condition can occur wherein all the nodes attempt to join as an ETCD learner at the same time. This results in only one being successful, and all of the other nodes reporting that their given plan has failed. Ideally, we should not mark a plan as failed if the error is transient & benign. We should only exclude specific errors that we know are recoverable and not representative of an invalid cluster configuration. This includes the `too many learner members in cluster` which is often encountered when creating K3s clusters. 

Solution: 
Wrap the k3s installation command in a for loop, and reattempt its execution if we can determine that it failed to to the `too many learner members in cluster` error. If a different error is encountered, we should still report that the plan has failed by providing a non zero exit code. 

The implementation in this PR works and prevents the script from exiting if we encounter the `too many learner members in cluster` error. I do have a few questions to reviewers though

1. Is there a better way to gather the logs for the latest startup of k3s? I could not find a way to do this using `journalctl` directly, but this is required for us to catch other errors that may be encountered after successfully joining etcd.
2. Do we want to capture other ETCD errors, or just leave it at this one? 

Bash isn't my forte as of yet, so I'm happy to hear constructive criticism on how to make this more idiomatic / portable. 

Testing: 

1. Create a new K3s cluster
4. Create a single node pool with all roles
5. Create 3 or more nodes within this node pool (the more nodes the more readily this error will reproduce) 
6. Ensure that the UI does not report an error message if the installation command results in the 'too many learner members in cluster' error. This can be determined by both looking at the Rancher UI for any errors, and by looking at output `journalctl -u rancher-system-agent.service`. In cases where an error is reported, the agent logs should be checked to ensure it is not the `too many learner members` error. 


Caveats: 
The behavior will not change if the system does not have access to `journalctl` on first boot, and will still result in the script returning a non-zero exit code if we cannot join ETCD as a learner. 

