### PR TITLE
Work around drone/git being broken on arm

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -99,7 +99,13 @@ platform:
   os: linux
   arch: arm
 
+clone:
+  disable: true
+
 steps:
+- name: clone
+  image: drone/git:latest-arm
+
 - name: build-linux-arm
   image: rancher/dapper:v0.4.1
   environment:


### PR DESCRIPTION
Broken by https://github.com/drone/drone-git/pull/48 removing arm from supported architectures

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>