### PR TITLE
Adjust `run.sh` ETCD learner error handling for better portability

### DIFF
--- a/package/run.sh
+++ b/package/run.sh
@@ -26,25 +26,24 @@ fi
 DELAY=10
 while ! env "INSTALL_K3S_FORCE_RESTART=${FORCE_RESTART}" "INSTALL_K3S_SKIP_DOWNLOAD=true" "INSTALL_K3S_SKIP_SELINUX_RPM=true" "INSTALL_K3S_SELINUX_WARN=true" installer.sh $@
 do
-    if ! systemctl cat k3s.service > /dev/null && echo $?; then
-        # if k3s.service can not be found then we are not a server node and thus will never encounter the 'too many learners' error, so we should just exit
+
+    # Get the last time the service started using the ExecMainStartTimestamp property
+    START=$(systemctl show k3s.service --property=ExecMainStartTimestamp | cut -f2 -d=)
+
+    # if START is n/a or empty, we know we do not have access to the k3s.service and thus are
+    # running on a worker node which can not encounter the ETCD error, so we should just exit
+    if [ "$START" == "n/a" ] || [ -z "$START" ]; then
         echo "not a K3s server, not attempting error remediation"
         exit 1
     fi
-    # We need to get the right systemd service based off of the role we have, $INSTALL_K3S_EXEC will be set if we are a worker only node, in which case the systemd service is k3s-agent.service
-    journalctl -u k3s.service > k3s-service.txt
-    # Only use the logs for the latest restart of k3s, otherwise errors encountered after an ETCD join error will not be reported properly.
-    LAST_START_LINE=$(cat k3s-service.txt | grep "Starting k3s v1." -n  | cut -d: -f1 | tail -1)
-    if [[ "$LAST_START_LINE" -gt 0 ]]; then
-        LAST_LOGS=$(cat k3s-service.txt | sed -n "$((LAST_START_LINE))"',$p')
-        else
-        LAST_LOGS=$(cat k3s-service.txt)
-    fi
-    if ! echo "${LAST_LOGS}" | grep "ETCD join failed: etcdserver: too many learner members in cluster" -q && echo $?; then
-        exit 1
-        else
+
+    # Get the logs since the last time the service started and check for the given error
+    if journalctl -u k3s.service --since="${START}" | grep -qF "etcdserver: too many learner members in cluster"; then
         # We couldn't register as a learner, keep trying until we can
         sleep "${DELAY}"
+    else
+        # if we have an error that isn't an etcd learner member error we shouldn't retry
+        exit 1
     fi
 done
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/system-agent-installer-k3s/issues/19

## Problem:
The prior implementation of the 'too many ETCD learners' error detection and handling was not portable enough, and on Ubuntu 22.04 the conditional on line 38 would not work due to shell specific syntax. 

## Solution:
Update how we gather the most recent k3s logs. Notably, we remove the offending conditional and do not cat the `k3s.service` logs any more. This should reduce the output of the system-agent logs. When this error is encountered the system-agent will only produce the following logs

```
Job for k3s.service failed because the control process exited with error code."
 See \"systemctl status k3s.service\" and \"journalctl -xe\" for details."
 + systemctl cat k3s.service"
 + systemctl show k3s.service --property=ExecMainStartTimestamp"
 + cut -f2 -d="
 + START=Mon 2023-05-01 21:33:35 UTC"
 + cut+  -f1 -d+"
 date -d Mon 2023-05-01 21:33:35 UTC --rfc-3339=seconds"
 + DATE=2023-05-01 21:33:35"
 + journalctl -u k3s.service --since=2023-05-01 21:33:35"
 + grep ETCD join failed: etcdserver: too many learner members in cluster -q"
 + sleep 10"
```


The `ExecMainStartTimestamp` property is used to get the most recent k3s startup time, that time is then formatted (as `journalctl` will not accept the default formatting used for the `ExecMainStartTimestamp` property value)  and passed to `journalctl` in the `--since` flag to get the most recent / relevant logging. 

These changes should make the installer more portable, but if there is a command which would prevent portability let me know and I'll think of something else. 

## Testing:
I have built a custom k3s installer image on version `v1.25.9` and used it to provision clusters in Rancher. I saw that clusters came up successfully, and in scenarios where an ETCD learner error may be encountered (3+ ETCD nodes being created at once during cluster initialization) I saw proper handling of that error (the plan was not marked as failed, thus no error in Rancher was seen). I did this testing on Ubuntu 20.04 as well as 22.04. 
