### PR TITLE
Add dependabot label and reviewer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,18 @@ updates:
   # Maintain dependencies for Docker Images
   - package-ecosystem: "docker"
     directory: "/"
+    labels:
+      - "kind/dependabot"
+    reviewers:
+      - "rancher/k3s"
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "docker"
     directory: "/package"
+    labels:
+      - "kind/dependabot"
+    reviewers:
+      - "rancher/k3s"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This will add the `k3s-io/k3s-dev` group to dependabot PRs.
This will add the `kind/dependabot` label to dependabot PRs.

This contributes to https://github.com/k3s-io/k3s/issues/7398
This contributes to https://github.com/k3s-io/k3s/issues/7350

I tested this by running [the dependabot cli](https://github.com/dependabot/cli) locally:
<details>
  <summary>Test Scenario</summary>

```
{
  "input": {
    "job": {
      "package-manager": "docker",
      "allowed-updates": [
        {
          "update-type": "all"
        }
      ],
      "source": {
        "provider": "github",
        "repo": "matttrach/system-agent-installer-k3s",
        "directory": "/",
        "commit": "e64f86cf8c0219fe7aebe87865966b69cddcbdec"
      },
      "credentials-metadata": [
        {
          "host": "github.com",
          "type": "git_source"
        }
      ]
    },
    "credentials": [
      {
        "host": "github.com",
        "password": "$LOCAL_GITHUB_ACCESS_TOKEN",
        "type": "git_source",
        "username": "x-access-token"
      }
    ]
  },
  "output": [
    {
      "type": "update_dependency_list",
      "expect": {
        "data": {
          "dependencies": [
            {
              "name": "alpine",
              "requirements": [
                {
                  "file": "Dockerfile.dapper",
                  "groups": [],
                  "requirement": null,
                  "source": {
                    "tag": "3.17"
                  }
                }
              ],
              "version": "3.17"
            }
          ],
          "dependency_files": [
            "/Dockerfile.dapper"
          ]
        }
      }
    },
    {
      "type": "mark_as_processed",
      "expect": {
        "data": {
          "base-commit-sha": "e64f86cf8c0219fe7aebe87865966b69cddcbdec"
        }
      }
    }
  ]
}
```

</details>