### PR TITLE
Add data-dir support

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,4 @@
 FROM scratch
 
-ARG K3S_DATA_DIR
-ENV K3S_DATA_DIR=${K3S_DATA_DIR}
-
 COPY package/run.sh /run.sh
 COPY artifacts/* /

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,7 @@
 FROM scratch
 
+ARG K3S_DATA_DIR
+ENV K3S_DATA_DIR=${K3S_DATA_DIR}
+
 COPY package/run.sh /run.sh
 COPY artifacts/* /

--- a/package/run.sh
+++ b/package/run.sh
@@ -2,13 +2,15 @@
 
 set -x -e
 
+K3S_DATA_DIR=${K3S_DATA_DIR:-/var/lib/rancher/k3s}
+
 cp -f ${CATTLE_AGENT_EXECUTION_PWD}/k3s /usr/local/bin/k3s
 chmod 755 /usr/local/bin/k3s
 chown root:root /usr/local/bin/k3s
 
-mkdir -p /var/lib/rancher/k3s
+mkdir -p ${K3S_DATA_DIR}
 
-RESTART_STAMP_FILE=/var/lib/rancher/k3s/restart_stamp
+RESTART_STAMP_FILE=${K3S_DATA_DIR}/restart_stamp
 
 if [ -f "${RESTART_STAMP_FILE}" ]; then
     PRIOR_RESTART_STAMP=$(cat "${RESTART_STAMP_FILE}");


### PR DESCRIPTION
DO NOT MERGE until May patches are shipped for K3s. This must go in before June patches in order to be included in the 2.9.0 release of Rancher.

Adds support for configuring the `data-dir` within K3s.