### PR TITLE
Revert "Harden"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,18 +2,8 @@ TARGETS := $(shell ls scripts)
 
 .dapper:
 	@echo Downloading dapper
-	@DAPPER_BINARY="dapper-$$(uname -s)-$$(uname -m)"; \
-	case "$$DAPPER_BINARY" in \
-		dapper-Linux-x86_64)  DAPPER_SHA256="ff6105ec0a2a973d972810a2dbdb9a6bae65031d286eae082d6779e04e4c2255" ;; \
-		dapper-Linux-aarch64) DAPPER_SHA256="cbc133224cca7593482855d8dcdec247288ec83f0fc99fbbe0ad8423260930ff" ;; \
-		dapper-Linux-arm)     DAPPER_SHA256="5455fb8663fddc41f32feb426aa85599d7595a87ffed5144e89e1ecc88a3586b" ;; \
-		dapper-Darwin-x86_64) DAPPER_SHA256="850e5f867d9d04840b64b159a8a74dcb56f964185c4bd6631941df738cbc98b4" ;; \
-		dapper-Darwin-arm64)  DAPPER_SHA256="ca0a5c32341e6474f9140433110153e0eef304ef74d0a830194428b103e7b52e" ;; \
-		*) echo "No pinned SHA256 for dapper on platform: $$DAPPER_BINARY" >&2; exit 1 ;; \
-	esac; \
-	curl -fsSL "https://releases.rancher.com/dapper/latest/$$DAPPER_BINARY" > .dapper.tmp; \
-	echo "$$DAPPER_SHA256  .dapper.tmp" | sha256sum -c -
-	@chmod +x .dapper.tmp
+	@curl -sL https://releases.rancher.com/dapper/latest/dapper-$$(uname -s)-$$(uname -m) > .dapper.tmp
+	@@chmod +x .dapper.tmp
 	@./.dapper.tmp -v
 	@mv .dapper.tmp .dapper
 

--- a/scripts/download
+++ b/scripts/download
@@ -25,16 +25,12 @@ if [[ -z "${LOCAL_ARTIFACTS}" ]]; then
     else
         SUFFIX="-${ARCH}"
     fi
-    pushd artifacts
+
     if [ -n "${PRIME_RIBS}" ]; then
-        curl -sfL -R -o "k3s${SUFFIX}" https://${PRIME_RIBS}/k3s/${URI_VERSION}/k3s${SUFFIX}
-        curl -sfL -R -o sha256sum-${ARCH}.txt https://${PRIME_RIBS}/k3s/${URI_VERSION}/sha256sum-${ARCH}.txt
+        curl -sfL -R -o artifacts/k3s https://${PRIME_RIBS}/k3s/${URI_VERSION}/k3s${SUFFIX}
     else
-        curl -sfL -R -o "k3s${SUFFIX}" https://github.com/k3s-io/k3s/releases/download/${URI_VERSION}/k3s${SUFFIX}
-        curl -sfL -R -o sha256sum-${ARCH}.txt https://github.com/k3s-io/k3s/releases/download/${URI_VERSION}/sha256sum-${ARCH}.txt
+        curl -sfL -R -o artifacts/k3s https://github.com/k3s-io/k3s/releases/download/${URI_VERSION}/k3s${SUFFIX}
     fi
-    grep -E "^[0-9a-f]+  k3s${SUFFIX}$" sha256sum-${ARCH}.txt | sha256sum -c -
-    popd
 else
     cp local/* artifacts
     chmod +x artifacts/installer.sh

--- a/scripts/version
+++ b/scripts/version
@@ -9,7 +9,7 @@ if [ -z "$OS" ]; then
     OS="linux"
 fi
 
-FALLBACK_VERSION=v1.35.2+k3s1
+FALLBACK_VERSION=v1.21.13+k3s1
 
 # This version script expects either a tag of format: <k3s-version> or no tag at all.
 


### PR DESCRIPTION
Reverts rancher/system-agent-installer-k3s#40

Reason: Created a bug in Rancher provisioning due to `image rancher/system-agent-installer-k3s:v1.35.3-k3s1` contains the k3s binary named `k3s-arm64` instead of k3s, while rancher expects its name to be k3s on all platforms.