### PR TITLE
Move the suffixed k3s binary 

### DIFF
--- a/scripts/download
+++ b/scripts/download
@@ -33,7 +33,9 @@ if [[ -z "${LOCAL_ARTIFACTS}" ]]; then
         curl -sfL -R -o "k3s${SUFFIX}" https://github.com/k3s-io/k3s/releases/download/${URI_VERSION}/k3s${SUFFIX}
         curl -sfL -R -o sha256sum-${ARCH}.txt https://github.com/k3s-io/k3s/releases/download/${URI_VERSION}/sha256sum-${ARCH}.txt
     fi
-    grep -E "^[0-9a-f]+  k3s${SUFFIX}$" sha256sum-${ARCH}.txt | sha256sum -c -
+    mv -f "k3s${SUFFIX}" k3s || true
+    sed -i "s/k3s${SUFFIX}$/k3s/" sha256sum-${ARCH}.txt
+    grep -E "^[0-9a-f]+  k3s$" sha256sum-${ARCH}.txt | sha256sum -c -
     popd
 else
     cp local/* artifacts


### PR DESCRIPTION
Ensure built image contains a `k3s` binary without an arch suffix

Fixup: 2a8e7ee3bb37c69f6f404e918811d0457c40ae1e